### PR TITLE
Better envs support, and various fixes

### DIFF
--- a/standaloner/src/vite.ts
+++ b/standaloner/src/vite.ts
@@ -14,7 +14,7 @@ export { standaloner as default, standaloner };
 
 const standaloner = (
   options: {
-    bundle?: boolean | string | Omit<BundleOptions, 'root' | 'external' | 'output' | 'cleanup'>;
+    bundle?: boolean | string | Omit<BundleOptions, 'root' | 'external' | 'cleanup'>;
     minify?: boolean;
     trace?: boolean;
     external?: (string | RegExp)[];
@@ -99,6 +99,7 @@ const standaloner = (
             input,
             external: options.external,
             output: {
+              ...bundleOptions.output,
               dir: outDir,
               minify,
               sourcemap: config.build.sourcemap,


### PR DESCRIPTION
- fix: only try to bundle "server" environment, based on `consumer` property
- fix: do not concat `outDir` when its absolute
- fix: when `bundle: true`, build files at the same place as inputs
- feat: allow overriding `bundleOptions.output`