### PR TITLE
fix: object input parsing

### DIFF
--- a/standaloner/src/vite.ts
+++ b/standaloner/src/vite.ts
@@ -14,7 +14,13 @@ export { standaloner as default, standaloner };
 
 const standaloner = (
   options: {
-    bundle?: boolean | string | string[] | Omit<BundleOptions, 'root' | 'external' | 'cleanup'>;
+    bundle?:
+      | boolean
+      | string
+      | string[]
+      | (Omit<BundleOptions, 'input' | 'root' | 'external' | 'cleanup'> & {
+          input?: string | string[] | Record<string, string>;
+        });
     minify?: boolean;
     trace?: boolean;
     external?: (string | RegExp)[];
@@ -80,15 +86,16 @@ const standaloner = (
 
         if (bundle_) {
           function getInputOption() {
-            if (typeof bundle_ === 'object' && bundle_.input) {
-              if (typeof bundle_.input === 'string') {
-                const bundleEntry = entries.find(e => e.name === bundle_.input);
+            if (typeof bundle_ === 'object' && !Array.isArray(bundle_) && bundle_.input) {
+              const inputOption = bundle_.input;
+              if (typeof inputOption === 'string') {
+                const bundleEntry = entries.find(e => e.name === inputOption);
                 return bundleEntry ? [bundleEntry.outPath] : outPaths;
-              } else if (Array.isArray(bundle_.input)) {
-                const matched = entries.filter(e => bundle_.input.includes(e.name));
+              } else if (Array.isArray(inputOption)) {
+                const matched = entries.filter(e => e.name && inputOption.includes(e.name));
                 return matched.length > 0 ? matched.map(e => e.outPath) : outPaths;
-              } else if (typeof bundle_.input === 'object') {
-                return Object.values(bundle_.input).map(p => path.isAbsolute(p) ? p : path.resolve(config.root, p));
+              } else if (typeof inputOption === 'object') {
+                return Object.values(inputOption as Record<string, string>).map(p => path.isAbsolute(p) ? p : path.resolve(config.root, p));
               }
             }
             const bundleEntryName = typeof bundle_ === 'string' ? bundle_ : 'index';
@@ -96,7 +103,7 @@ const standaloner = (
             return bundleEntry ? [bundleEntry.outPath] : outPaths;
           }
 
-          const bundleOptions = typeof bundle_ === 'object' ? bundle_ : {};
+          const bundleOptions = typeof bundle_ === 'object' && !Array.isArray(bundle_) ? bundle_ : {};
           // Respect the input name if object is provided.
           // Examples:
           // - { input: { file1: './path/file.mjs' } } → 'file1.mjs'
@@ -105,8 +112,8 @@ const standaloner = (
           // - { input: ['./path/file1.mjs', './path/file2.mjs'] } → 'file1.mjs' + 'file1.mjs'
           const input = Object.fromEntries(
             typeof bundleOptions.input === 'object' && bundleOptions.input !== null && !Array.isArray(bundleOptions.input)
-              ? Object.entries(bundleOptions.input).map(([k, v]) => [k, path.isAbsolute(v) ? v : path.resolve(config.root, v)])
-              : getInputOption().map(e => [removeExtension(pathRelativeTo(e, outDir)), e])
+              ? Object.entries(bundleOptions.input).map(([k, v]) => [k, path.isAbsolute(v as string) ? (v as string) : path.resolve(config.root, v as string)])
+              : getInputOption().map((e: string) => [removeExtension(pathRelativeTo(e, outDir)), e])
           );
           await bundle({
             ...bundleOptions,

--- a/standaloner/src/vite.ts
+++ b/standaloner/src/vite.ts
@@ -14,7 +14,7 @@ export { standaloner as default, standaloner };
 
 const standaloner = (
   options: {
-    bundle?: boolean | string | Omit<BundleOptions, 'root' | 'external' | 'cleanup'>;
+    bundle?: boolean | string | string[] | Omit<BundleOptions, 'root' | 'external' | 'cleanup'>;
     minify?: boolean;
     trace?: boolean;
     external?: (string | RegExp)[];

--- a/standaloner/src/vite.ts
+++ b/standaloner/src/vite.ts
@@ -80,12 +80,20 @@ const standaloner = (
 
         if (bundle_) {
           function getInputOption() {
-            const bundleEntryName = typeof bundle_ === 'object' && typeof bundle_.input === 'string' ? bundle_.input :  typeof bundle_ === 'string' ? bundle_ : 'index';
-            const bundleEntry = entries.find(e => e.name === bundleEntryName);
-            if (!bundleEntry) {
-              return outPaths;
+            if (typeof bundle_ === 'object' && bundle_.input) {
+              if (typeof bundle_.input === 'string') {
+                const bundleEntry = entries.find(e => e.name === bundle_.input);
+                return bundleEntry ? [bundleEntry.outPath] : outPaths;
+              } else if (Array.isArray(bundle_.input)) {
+                const matched = entries.filter(e => bundle_.input.includes(e.name));
+                return matched.length > 0 ? matched.map(e => e.outPath) : outPaths;
+              } else if (typeof bundle_.input === 'object') {
+                return Object.values(bundle_.input).map(p => path.isAbsolute(p) ? p : path.resolve(config.root, p));
+              }
             }
-            return [bundleEntry.outPath];
+            const bundleEntryName = typeof bundle_ === 'string' ? bundle_ : 'index';
+            const bundleEntry = entries.find(e => e.name === bundleEntryName);
+            return bundleEntry ? [bundleEntry.outPath] : outPaths;
           }
 
           const bundleOptions = typeof bundle_ === 'object' ? bundle_ : {};

--- a/standaloner/src/vite.ts
+++ b/standaloner/src/vite.ts
@@ -97,8 +97,17 @@ const standaloner = (
           }
 
           const bundleOptions = typeof bundle_ === 'object' ? bundle_ : {};
-          // Input to object, so that entries are written at the same place
-          const input = Object.fromEntries(getInputOption().map(e => [removeExtension(pathRelativeTo(e, outDir)), e]));
+          // Respect the input name if object is provided.
+          // Examples:
+          // - { input: { file1: './path/file.mjs' } } → 'file1.mjs'
+          // - { input: './path/file.mjs' } → 'index.mjs'
+          // - { input: { nameFile1: './path/file1.mjs', nameFile2: './path/file2.mjs' } } → 'nameFile1.mjs' + 'nameFile1.mjs'
+          // - { input: ['./path/file1.mjs', './path/file2.mjs'] } → 'file1.mjs' + 'file1.mjs'
+          const input = Object.fromEntries(
+            typeof bundleOptions.input === 'object' && bundleOptions.input !== null && !Array.isArray(bundleOptions.input)
+              ? Object.entries(bundleOptions.input).map(([k, v]) => [k, path.isAbsolute(v) ? v : path.resolve(config.root, v)])
+              : getInputOption().map(e => [removeExtension(pathRelativeTo(e, outDir)), e])
+          );
           await bundle({
             ...bundleOptions,
             input,


### PR DESCRIPTION
# Standaloner Bug Fix: Object Input Parsing

The `standaloner` Vite plugin had a bug where it failed to process multiple entry points if they were passed as an object to the `bundle.input` property. 

By default, Vite projects with Vike generate multiple entries in the Server-Side Rendering (SSR) build (`index`, `entrypoint`, `pages_index`, etc.), and Rolldown/Vite extracts shared code between them into `chunks`.

## The Bug
When you configured `standaloner` to bundle both `entrypoint.mjs` and `index.mjs` via an object:

```typescript
// vite.config.ts
input: {
  entrypoint: '../dist/server/entrypoint.mjs',
  index: '../dist/server/index.mjs'
}
```

The underlying code in `node_modules/standaloner/dist/vite.js` evaluated this line:
```javascript
const bundleEntryName = typeof bundle_ === 'object' && typeof bundle_.input === 'string' ? bundle_.input : typeof bundle_ === 'string' ? bundle_ : 'index';
```

Because `typeof bundle_.input === 'string'` is `false` (it's an object!), the plugin **ignored your object completely** and fell back to searching exclusively for an entry named `'index'`. 

It then bundled ONLY `index.mjs`, and because the internal `cleanup: true` flag was active, it subsequently deleted all the `.js` chunks that were no longer needed by `index.mjs`. However, `entrypoint.mjs` was left unbundled and its imported chunks were deleted, completely breaking it.

## The Patch

I created a patch using `pnpm patch standaloner@0.2.2`. 

The patch modifies the `getInputOption()` function in `standaloner/dist/vite.js` to correctly support objects and arrays. If you pass an object with file paths, it maps those paths securely to absolute paths and returns them so `standaloner` can bundle all of them concurrently:

```javascript
// C:\workspace\0-Templates\template-vike-solid-daisyui-hono\node_modules\.pnpm_patches\standaloner@0.2.2\dist\vite.js

function getInputOption() {
    // [NEW LOGIC] - Handles arrays and objects correctly
    if (typeof bundle_ === 'object' && bundle_.input) {
        if (typeof bundle_.input === 'string') {
            const bundleEntry = entries.find(e => e.name === bundle_.input);
            return bundleEntry ? [bundleEntry.outPath] : outPaths;
        } else if (Array.isArray(bundle_.input)) {
            const matched = entries.filter(e => bundle_.input.includes(e.name));
            return matched.length > 0 ? matched.map(e => e.outPath) : outPaths;
        } else if (typeof bundle_.input === 'object') {
            return Object.values(bundle_.input).map(p => path.isAbsolute(p) ? p : path.resolve(config.root, p));
        }
    }
    
    // [OLD LOGIC FALLBACK] - Defaults to 'index' or 'outPaths'
    const bundleEntryName = typeof bundle_ === 'string' ? bundle_ : 'index';
    const bundleEntry = entries.find(e => e.name === bundleEntryName);
    return bundleEntry ? [bundleEntry.outPath] : outPaths;
}
```

## Verification

The patch has been automatically applied and committed to your workspace using `pnpm patch-commit`. Your `package.json` has been updated with a `pnpm.patchedDependencies` field, and a `patches/` folder was created. 

If you check the size of `/dist/server/entrypoint.mjs` after running a build, it is now around `376KB`, meaning it has been successfully bundled as a single, standalone file just like `/dist/server/index.mjs`!

## Bug Reproduction

https://github.com/templates-ecosystem/template-vike-solid-daisyui-hono/tree/minimal-server-vercel (commit [e39f51f](https://github.com/templates-ecosystem/template-vike-solid-daisyui-hono/commit/e39f51f9d7090bc424b18333f76f4f67c20b220d))

## Reproduction with patched `standaloner` (changes of this PR)

https://github.com/templates-ecosystem/template-vike-solid-daisyui-hono/tree/minimal-server-vercel (commit [2a411c0](https://github.com/templates-ecosystem/template-vike-solid-daisyui-hono/commit/2a411c042d9feffe309757f1daa7d113ad653297))

## Related Issue

https://github.com/vikejs/vike/issues/3223#issuecomment-4284258929