### PR TITLE
feat: add Plug'n'Play (PnP) support

### DIFF
--- a/standaloner/src/relocate.ts
+++ b/standaloner/src/relocate.ts
@@ -23,7 +23,15 @@ const safeRequireResolve = (
   importer?: string
 ): string | undefined => {
   try {
-    const req = importer ? createRequire(importer) : require;
+    let req = require;
+    if (importer) {
+      let cleanedImporter = importer;
+      if (cleanedImporter.startsWith('\0')) cleanedImporter = cleanedImporter.slice(1);
+      cleanedImporter = cleanedImporter.replace(/[?#].*$/, '');
+      if (path.isAbsolute(cleanedImporter)) {
+        req = createRequire(cleanedImporter);
+      }
+    }
     return toPosixPath(req.resolve(request));
   } catch {
     return undefined;

--- a/standaloner/src/relocate.ts
+++ b/standaloner/src/relocate.ts
@@ -603,7 +603,7 @@ function processRequireCall(node: CallExpression, dirName: string, sourceId: str
   return [
     {
       node: arg,
-      path: modulePath,
+      path: potentialPath,
       transformInfo: {
         type: 'require',
         start: node.start,

--- a/standaloner/src/relocate.ts
+++ b/standaloner/src/relocate.ts
@@ -20,10 +20,11 @@ const require = createRequire(import.meta.url);
 
 const safeRequireResolve = (
   request: string,
-  options?: { paths?: string[] | undefined }
+  importer?: string
 ): string | undefined => {
   try {
-    return toPosixPath(require.resolve(request, options));
+    const req = importer ? createRequire(importer) : require;
+    return toPosixPath(req.resolve(request));
   } catch {
     return undefined;
   }
@@ -111,7 +112,7 @@ export function assetRelocatorPlugin(options: AssetRelocatorOptions = {}): Plugi
     },
 
     async resolveId(source, importer, options) {
-      return (await this.resolve(source, importer, options)) || safeRequireResolve(source);
+      return (await this.resolve(source, importer, options)) || safeRequireResolve(source, importer);
     },
 
     async load(id: string) {
@@ -384,7 +385,7 @@ function findFileReferences(ast: Program, dirName: string, sourceId: string): Fi
       } else if (isPathJoinOperation(node)) {
         ref = processPathJoinOperation(node as CallExpression, dirName);
       } else if (isRequireCall(node)) {
-        ref = processRequireCall(node as CallExpression, dirName);
+        ref = processRequireCall(node as CallExpression, dirName, sourceId);
       } else if (isFsOperation(node)) {
         ref = processFsOperation(node as CallExpression, dirName);
       }
@@ -566,7 +567,7 @@ function isRequireCall(node: Node): node is CallExpression {
 }
 
 /** Process require() call */
-function processRequireCall(node: CallExpression, dirName: string): FileReference[] | null {
+function processRequireCall(node: CallExpression, dirName: string, sourceId: string): FileReference[] | null {
   const arg = node.arguments[0];
   if (!arg) return null;
 
@@ -578,7 +579,7 @@ function processRequireCall(node: CallExpression, dirName: string): FileReferenc
   }
   if (!modulePath) return null;
 
-  const resolved = safeRequireResolve(modulePath);
+  const resolved = safeRequireResolve(modulePath, sourceId);
   const potentialPath = resolved || path.resolve(dirName, modulePath);
   const ext = path.extname(potentialPath).toLowerCase();
   if (['.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx', '.json', ''].includes(ext)) return null;

--- a/standaloner/src/trace.ts
+++ b/standaloner/src/trace.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { createRequire } from 'node:module';
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { platform } from 'node:os';
@@ -90,13 +91,6 @@ async function trace({
   assert(input.length > 0, 'Input must be non-empty');
   logVerbose('Tracing package dependencies...');
 
-  // Check for unsupported PnP
-  try {
-    require('pnpapi');
-    logInfo('Warning: Yarn PnP detected, which is not supported. Skipping trace.');
-    return;
-  } catch {} // PnP not in use, proceed
-
   // Prepare output directories
   const nodeModulesPath = path.join(outDir, nodeModulesDir);
   const versionsPath = path.join(nodeModulesPath, versionsDir);
@@ -174,6 +168,12 @@ async function traceProjectFiles(
       try {
         return await nftDefaultResolve(id, parent, job, cjsResolve);
       } catch (err) {
+        try {
+          const parentFile = parent ? path.resolve(baseDir, parent) : path.join(baseDir, 'index.js');
+          const req = createRequire(parentFile);
+          return toPosixPath(req.resolve(id));
+        } catch {}
+
         const fallback = await pickLatestOrigin(id);
         if (fallback) return fallback;
         throw err;

--- a/standaloner/src/trace.ts
+++ b/standaloner/src/trace.ts
@@ -172,11 +172,11 @@ async function traceProjectFiles(
           const parentFile = parent ? path.resolve(baseDir, parent) : path.join(baseDir, 'index.js');
           const req = createRequire(parentFile);
           return toPosixPath(req.resolve(id));
-        } catch {}
-
-        const fallback = await pickLatestOrigin(id);
-        if (fallback) return fallback;
-        throw err;
+        } catch {
+          const fallback = await pickLatestOrigin(id);
+          if (fallback) return fallback;
+          throw err;
+        }
       }
     },
   });

--- a/test/pnp/test.js
+++ b/test/pnp/test.js
@@ -17,15 +17,16 @@ const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'standaloner-pnp-test-'));
 console.log(`Created temporary Yarn PnP directory: ${tmpDir}`);
 
 try {
-  // 1. Initialize Yarn PnP project
+  // 1. Initialize Yarn PnP project non-interactively
   console.log('Initializing Yarn PnP project...');
-  execSync('corepack yarn init -2', { stdio: 'inherit', cwd: tmpDir });
-
-  // Add type: module to package.json to test ESM
   const pkgJsonPath = path.join(tmpDir, 'package.json');
-  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
-  pkgJson.type = 'module';
-  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
+  fs.writeFileSync(pkgJsonPath, JSON.stringify({
+    name: 'standaloner-pnp-test',
+    private: true,
+    type: 'module'
+  }, null, 2));
+  execSync('corepack yarn set version berry', { stdio: 'inherit', cwd: tmpDir });
+  execSync('corepack yarn install', { stdio: 'inherit', cwd: tmpDir });
 
   // 2. Install a dependency (lodash) and 3. install the local standaloner package
   console.log('Installing dependencies (lodash, local standaloner)...');

--- a/test/pnp/test.js
+++ b/test/pnp/test.js
@@ -1,0 +1,87 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// The root of the standaloner package, for installing local dependency setup properly
+const localStandalonerPath = path.resolve(__dirname, '../../standaloner');
+// Format path for Yarn (file: protocol format requires front slashes)
+const yarnStandalonerPath = 'file:' + localStandalonerPath.replace(/\\/g, '/');
+
+// Create a totally isolated temporary directory for the Yarn PnP test
+// This is to avoid triggering any parent `package.json` packageManager flags (like pnpm workspace)
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'standaloner-pnp-test-'));
+console.log(`Created temporary Yarn PnP directory: ${tmpDir}`);
+
+try {
+  // 1. Initialize Yarn PnP project
+  console.log('Initializing Yarn PnP project...');
+  execSync('corepack yarn init -2', { stdio: 'inherit', cwd: tmpDir });
+
+  // Add type: module to package.json to test ESM
+  const pkgJsonPath = path.join(tmpDir, 'package.json');
+  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+  pkgJson.type = 'module';
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
+
+  // 2. Install a dependency (lodash) and 3. install the local standaloner package
+  console.log('Installing dependencies (lodash, local standaloner)...');
+  execSync('corepack yarn add lodash', { stdio: 'inherit', cwd: tmpDir });
+  execSync(`corepack yarn add standaloner@${yarnStandalonerPath}`, { stdio: 'inherit', cwd: tmpDir });
+
+  // 4. Create a basic JS file that imports the dependency
+  console.log('Creating source files...');
+  fs.writeFileSync(path.join(tmpDir, 'index.js'), `
+    import _ from 'lodash';
+    export const res = _.defaults({ 'a': 1 }, { 'a': 3, 'b': 2 });
+    console.log('Lodash merge result:', res);
+  `);
+
+  // Create a builder script
+  fs.writeFileSync(path.join(tmpDir, 'build.js'), `
+    import standaloner from 'standaloner';
+
+    console.log('Bundling index.js inside Yarn PnP...');
+    standaloner({
+      input: 'index.js',
+      outDir: 'dist',
+      bundle: true,
+      trace: true
+    }).then(() => {
+      console.log('Bundle finished.');
+    }).catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+  `);
+
+  // 5. Run standaloner to bundle it
+  console.log('Running standaloner builder script...');
+  execSync('corepack yarn node build.js', { stdio: 'inherit', cwd: tmpDir });
+
+  // 6. Execute the output to verify it works perfectly
+  console.log('Verifying output behaves as expected...');
+  // The output might default to .mjs or .js
+  let distEntry = path.join(tmpDir, 'dist', 'index.js');
+  if (!fs.existsSync(distEntry)) {
+    distEntry = path.join(tmpDir, 'dist', 'index.mjs');
+  }
+  if (!fs.existsSync(distEntry)) {
+    throw new Error(`Build output file dist/index.js or dist/index.mjs not found!`);
+  }
+
+  const output = execSync(`node ${distEntry}`, { stdio: 'pipe', cwd: tmpDir }).toString();
+  console.log('Execution output:', output);
+
+  if (output.includes('Lodash merge result: { a: 1, b: 2 }')) {
+    console.log('\u2714 Success: Output was bundled correctly and runs perfectly!');
+  } else {
+    throw new Error('Test logic failed! Expected lodash merged result in output.');
+  }
+} finally {
+  console.log('Cleaning up temporary isolated directory...');
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}

--- a/test/vite/test/pnp/index.js
+++ b/test/vite/test/pnp/index.js
@@ -1,0 +1,1 @@
+const _ = require('lodash'); const { builder } = require('standaloner'); async function run() { await builder({ entry: 'index.js', outDir: 'dist' }); } run();

--- a/test/vite/test/pnp/index.js
+++ b/test/vite/test/pnp/index.js
@@ -1,1 +1,1 @@
-const _ = require('lodash'); const { builder } = require('standaloner'); async function run() { await builder({ entry: 'index.js', outDir: 'dist' }); } run();
+const _ = require('lodash'); const standaloner = require('standaloner'); async function run() { await standaloner({ input: 'index.js', outDir: 'dist' }); } run();


### PR DESCRIPTION
Fix #6

### Description
This PR introduces support for Yarn Plug'n'Play (PnP) by leveraging Node's native [createRequire](https://nodejs.org/api/module.html#modulecreaterequirefilename) API to allow PnP to properly hook into the module resolution process.

### Motivation
Previously, `standaloner` relied heavily on static file-system resolution algorithms (like those built into `@vercel/nft`). This approach fundamentally breaks in PnP environments where a physical `node_modules` directory is absent. To fix this, we need to delegate dependency resolution to Node's native module system ([require.resolve](https://nodejs.org/api/modules.html#requireresolverequest-options)), which Yarn automatically patches at runtime to load dependencies directly from the `.yarn/cache`.

### Changes
- `src/trace.ts`:
  - Removed the early exit/guard that blocked execution when the `pnpapi` module was detected.
  - Updated the custom `resolve` hook for `nodeFileTrace`. If the default `@vercel/nft` resolver fails to find the file (which is expected in PnP), it now falls back to a context-aware `createRequire(parentFile).resolve(id)`. This triggers Yarn's patched resolver to correctly locate the file.
- `src/relocate.ts`:
  - Updated the `safeRequireResolve` utility to dynamically accept an `importer` file path context.
  - Passed the `importer`/`sourceId` through the AST walker (`processRequireCall`) and the `resolveId` bundler hook so that dependencies are resolved accurately relative to their importing file.

### Testing
- Re-built the project to ensure no TypeScript compilation errors.
- Verified that dependencies correctly resolve and bundle using the new context-aware `createRequire` logic.