### PR TITLE
fix: output.codeSplitting with multiple input files

### DIFF
--- a/standaloner/src/bundle.ts
+++ b/standaloner/src/bundle.ts
@@ -123,13 +123,15 @@ export const _bundle = (options: BundleOptions): Promise<RolldownOutput> => {
   plugins.push(assetRelocatorPlugin({ outputDir: '.static' }));
   plugins.push(buildExternalsPlugin(options.external));
 
+  const numInputs = Object.keys(options.input).length;
+  
   return build({
     platform: 'node',
     write: true,
     ...rest,
     plugins,
     output: {
-      codeSplitting: false,
+      codeSplitting: numInputs > 1,
       banner: generateBanner(),
       entryFileNames: '[name].mjs',
       chunkFileNames: '[name]-[hash].mjs',


### PR DESCRIPTION
Fix the failing test:
```shell
=== Testing Isolated Build Feature ===

Test 1: Building with isolated=true...
✓ Isolated build completed

Test 2: Building with isolated=false (normal)...
node:internal/modules/run_main:123
triggerUncaughtException(
^

[Error: [INVALID_OPTION] Error: Invalid value "false" for option "output.codeSplitting" - multiple inputs are not supported when "output.codeSplitting" is false.
] {
code: 'GenericFailure'
}
```

Inside `bundle.ts`, the configuration of the bundler (Rolldown) alwasy uses the value `output: { codeSplitting: false }`.
Rolldown should do the standard build with the shared chunks but it throws the error `[INVALID_OPTION]` because it got the option `codeSplitting: false` with multiple input files.

Related: https://github.com/nitedani/standaloner/actions/runs/24990193104/job/73173598411