### PR TITLE
refactor: code

### DIFF
--- a/standaloner/src/bundle.ts
+++ b/standaloner/src/bundle.ts
@@ -120,23 +120,23 @@ export const _bundle = (options: BundleOptions): Promise<RolldownOutput> => {
 
   const { cleanup, root, isolated, ...rest } = options;  // Set up plugins
   const plugins = [rest.plugins].flat().filter(Boolean);
-  plugins.push(assetRelocatorPlugin({ outputDir: '.static' }));
-  plugins.push(buildExternalsPlugin(options.external));
+  plugins.push(
+    assetRelocatorPlugin({ outputDir: '.static' }),
+    buildExternalsPlugin(options.external),
+  );
 
-  const numInputs = Object.keys(options.input).length;
-  
   return build({
     platform: 'node',
     write: true,
     ...rest,
     plugins,
     output: {
-      codeSplitting: numInputs > 1,
+      codeSplitting: Object.keys(options.input!).length > 1,
       banner: generateBanner(),
       entryFileNames: '[name].mjs',
       chunkFileNames: '[name]-[hash].mjs',
       strictExecutionOrder: true,
-      ...(rest.output || {}),
+      ...rest.output,
     },
   });
 }

--- a/standaloner/src/index.ts
+++ b/standaloner/src/index.ts
@@ -86,8 +86,9 @@ const standaloner = async (options: StandalonerOptions) => {
   plugins.push(viteTransformPlugin({ root }));
 
   const bundleOutput =
-    options.bundle !== false
-      ? await bundle({
+    options.bundle === false
+      ? null
+      : await bundle({
           ...bundleOptions,
           plugins,
           input: options.input,
@@ -97,8 +98,7 @@ const standaloner = async (options: StandalonerOptions) => {
           },
           cleanup: options.cleanup,
           root,
-        })
-      : null;
+        });
 
   if (shouldTrace) {
     await trace({

--- a/standaloner/src/relocate.ts
+++ b/standaloner/src/relocate.ts
@@ -339,14 +339,24 @@ export function assetRelocatorPlugin(options: AssetRelocatorOptions = {}): Plugi
 
         // Generate replacement based on type
         let replacement = '';
-        if (type === 'url') {
-          replacement = `new URL(${JSON.stringify(relativePathWithDot)}, import.meta.url)`;
-        } else if (type === 'path' || type === 'fs') {
-          replacement = `new URL(${JSON.stringify(relativePathWithDot)}, import.meta.url).pathname`;
-        } else if (type === 'require' || type === 'load') {
-          replacement = `require(${JSON.stringify(relativePathWithDot)})`;
-        } else {
-          assert(false, `Unknown reference type: ${type}`);
+        switch (type) {
+          case 'url': {
+            replacement = `new URL(${JSON.stringify(relativePathWithDot)}, import.meta.url)`;
+            break;
+          }
+          case 'path': 
+          case 'fs': {
+            replacement = `new URL(${JSON.stringify(relativePathWithDot)}, import.meta.url).pathname`;
+            break;
+          }
+          case 'require': 
+          case 'load': {
+            replacement = `require(${JSON.stringify(relativePathWithDot)})`;
+            break;
+          }
+          default: {
+            assert(false, `Unknown reference type: ${type}`);
+          }
         }
 
         logVerbose(`Replaced ${placeholder} with ${replacement} (type: ${type})`);
@@ -429,27 +439,25 @@ function processNewURLNode(node: NewExpression, dirName: string): FileReference[
     filePath = urlPathArg.quasis[0]?.value.cooked || null;
   }
 
-  if (filePath !== null) {
-    if (filePath.startsWith('.') || path.isAbsolute(filePath)) {
-      assert(
-        'start' in node &&
-          typeof node.start === 'number' &&
-          'end' in node &&
-          typeof node.end === 'number',
-        'Node requires start/end'
-      );
-      return [
-        {
-          node: urlPathArg,
-          path: filePath,
-          transformInfo: {
-            type: 'url',
-            start: node.start,
-            end: node.end,
-          },
+  if (filePath !== null && (filePath.startsWith('.') || path.isAbsolute(filePath!))) {
+    assert(
+      'start' in node &&
+        typeof node.start === 'number' &&
+        'end' in node &&
+        typeof node.end === 'number',
+      'Node requires start/end'
+    );
+    return [
+      {
+        node: urlPathArg,
+        path: filePath!,
+        transformInfo: {
+          type: 'url',
+          start: node.start,
+          end: node.end,
         },
-      ];
-    }
+      },
+    ];
   }
   return null;
 }
@@ -606,7 +614,7 @@ function processRequireCall(node: CallExpression, dirName: string): FileReferenc
 
 /** Check if node is fs.someFunc(...) */
 function isFsOperation(node: Node): node is CallExpression {
-  if (node.type !== 'CallExpression' || node.arguments.length < 1) return false;
+  if (node.type !== 'CallExpression' || node.arguments.length === 0) return false;
 
   const callee = node.callee;
   if (callee.type !== 'MemberExpression') return false;

--- a/standaloner/src/trace.ts
+++ b/standaloner/src/trace.ts
@@ -665,7 +665,7 @@ async function findOptionalDepRoot(
 
 async function readPkgJson(dir: string): Promise<PackageJson | null> {
   try {
-    return JSON.parse(await fs.readFile(path.join(dir, 'package.json'), 'utf-8'));
+    return JSON.parse(await fs.readFile(path.join(dir, 'package.json'), 'utf8'));
   } catch {
     return null;
   }
@@ -830,7 +830,7 @@ async function addNativeBinaries(tracedFiles: Record<string, TracedFile>): Promi
  */
 function compareVersions(v1 = DEFAULT_VERSION, v2 = DEFAULT_VERSION): number {
   // Basic parsing, ignores pre-release tags
-  const parsePart = (n: string): number => parseInt(n, 10) || 0;
+  const parsePart = (n: string): number => Number.parseInt(n, 10) || 0;
   const p1 = v1.split('-')[0]!.split('.').map(parsePart);
   const p2 = v2.split('-')[0]!.split('.').map(parsePart);
 

--- a/standaloner/src/utils/buildSummary.ts
+++ b/standaloner/src/utils/buildSummary.ts
@@ -96,7 +96,7 @@ class BuildSummary {
   // Record asset emission
   public recordAsset(filePath: string, size: number): void {
     const fileName = path.basename(filePath);
-    const fileExt = path.extname(filePath).toLowerCase().substring(1) || 'unknown';
+    const fileExt = path.extname(filePath).toLowerCase().slice(1) || 'unknown';
 
     // Update total stats
     this.assets.totalAssets++;
@@ -227,7 +227,7 @@ class BuildSummary {
         }
 
         // Display each file and its reference types
-        for (const [fileName, refs] of Array.from(fileGroups.entries()).sort()) {
+        for (const [fileName, refs] of [...fileGroups.entries()].sort()) {
           const types = refs.map(r => r.type).join(', ');
           console.log(`  ${fileName} (${types})`);
         }

--- a/standaloner/src/utils/resolveOptions.ts
+++ b/standaloner/src/utils/resolveOptions.ts
@@ -22,14 +22,11 @@ export const resolvePaths = (options: StandalonerOptions) => {
   const root = searchForPackageRoot(inputCommonDir);
 
   // Determine output directory
-  let outDir: string;
-  if (options.outDir) {
+  const outDir = options.outDir
     // If outDir is provided, resolve it relative to current working directory
-    outDir = path.resolve(process.cwd(), options.outDir);
-  } else {
+    ? path.resolve(process.cwd(), options.outDir)
     // If no outDir is provided, use a 'dist' subdirectory in the input common directory
-    outDir = path.join(inputCommonDir, 'dist');
-  }
+    : path.join(inputCommonDir, 'dist');
 
   // Find workspace root for monorepo support
   const baseDir = searchForWorkspaceRoot(inputCommonDir);

--- a/standaloner/src/utils/searchRoot.ts
+++ b/standaloner/src/utils/searchRoot.ts
@@ -28,7 +28,7 @@ function hasWorkspacePackageJSON(root: string): boolean {
     return false;
   }
   try {
-    const content = JSON.parse(fs.readFileSync(path, 'utf-8')) || {};
+    const content = JSON.parse(fs.readFileSync(path, 'utf8')) || {};
     return !!content.workspaces;
   } catch {
     return false;

--- a/test/assets/index.mjs
+++ b/test/assets/index.mjs
@@ -10,7 +10,7 @@ console.log('=== Asset Detection Test ===\n');
 console.log('1. Testing URL references (new URL):');
 try {
   const url1 = new URL('./test-data.txt', import.meta.url);
-  const content1 = fs.readFileSync(url1, 'utf-8');
+  const content1 = fs.readFileSync(url1, 'utf8');
   console.log('   ✓ test-data.txt via URL:', content1.trim());
 } catch (e) {
   console.error('   ✗ Failed to load test-data.txt via URL:', e.message);
@@ -34,7 +34,7 @@ try {
 console.log('\n2. Testing path.join with __dirname:');
 try {
   const configPath = path.join(__dirname, 'config.json');
-  const configContent = fs.readFileSync(configPath, 'utf-8');
+  const configContent = fs.readFileSync(configPath, 'utf8');
   const config = JSON.parse(configContent);
   console.log('   ✓ config.json via path.join:', config);
 } catch (e) {
@@ -44,7 +44,7 @@ try {
 
 try {
   const nestedPath = path.join(__dirname, 'data', 'nested-file.csv');
-  const nestedContent = fs.readFileSync(nestedPath, 'utf-8');
+  const nestedContent = fs.readFileSync(nestedPath, 'utf8');
   console.log('   ✓ nested-file.csv via path.join:', nestedContent.split('\n')[0]);
 } catch (e) {
   console.error('   ✗ Failed to load nested-file.csv via path.join:', e.message);
@@ -63,7 +63,7 @@ try {
 }
 
 try {
-  const content = fs.readFileSync(fileURLToPath(new URL('./config.json', import.meta.url)), 'utf-8');
+  const content = fs.readFileSync(fileURLToPath(new URL('./config.json', import.meta.url)), 'utf8');
   console.log('   ✓ fs.readFileSync on config.json:', content.length, 'bytes');
 } catch (e) {
   console.error('   ✗ Failed fs.readFileSync on config.json:', e.message);
@@ -79,7 +79,7 @@ try {
   const exists = fs.existsSync(nodePath);
   console.log('   ✓ mock.node file exists:', exists);
   if (exists) {
-    const content = fs.readFileSync(nodePath, 'utf-8');
+    const content = fs.readFileSync(nodePath, 'utf8');
     console.log('   ✓ mock.node content:', content.trim());
   }
 } catch (e) {

--- a/test/assets/test.js
+++ b/test/assets/test.js
@@ -53,7 +53,7 @@ const staticFiles = fs.readdirSync(staticDir, { recursive: true }).map(f => Stri
 console.log('\nAssets found in .static:');
 staticFiles.forEach(file => console.log('  -', file));
 
-let missingAssets = [];
+const missingAssets = [];
 for (const asset of expectedAssets) {
   const found = staticFiles.some(f => f.includes(path.basename(asset)));
   if (found) {

--- a/test/isolated/test.js
+++ b/test/isolated/test.js
@@ -79,13 +79,13 @@ console.log('✓ Isolated build has no shared chunks\n');
 const hasSharedChunks = normalFiles.some(f => 
   !['functionA.mjs', 'functionB.mjs', 'functionC.mjs'].includes(f)
 );
-if (!hasSharedChunks) {
-  console.log('⚠ Warning: Normal build did not create shared chunks (might be expected for small files)\n');
-} else {
+if (hasSharedChunks) {
   const sharedChunks = normalFiles.filter(f => 
     !['functionA.mjs', 'functionB.mjs', 'functionC.mjs'].includes(f)
   );
   console.log(`✓ Normal build created shared chunks: ${sharedChunks.join(', ')}\n`);
+} else {
+  console.log('⚠ Warning: Normal build did not create shared chunks (might be expected for small files)\n');
 }
 
 // Test 5: Verify isolated files are self-contained and executable

--- a/test/vite/test.js
+++ b/test/vite/test.js
@@ -28,7 +28,7 @@ const staticFiles = fs.readdirSync(staticDir, { recursive: true }).map(f => Stri
 console.log('\nAssets found in .static:');
 staticFiles.forEach(file => console.log('  -', file));
 
-let missingAssets = [];
+const missingAssets = [];
 for (const asset of expectedAssets) {
   const found = staticFiles.some(f => f.includes(asset));
   if (found) {
@@ -64,7 +64,7 @@ for (const file of expectedFiles) {
 console.log('\n=== Checking Asset References ===\n');
 const indexMjs = path.join(serverDir, 'index.mjs');
 if (fs.existsSync(indexMjs)) {
-  const indexContent = fs.readFileSync(indexMjs, 'utf-8');
+  const indexContent = fs.readFileSync(indexMjs, 'utf8');
 
   // Check that asset references were transformed
   const hasUrlTransform = indexContent.includes('new URL(') && indexContent.includes('import.meta.url');


### PR DESCRIPTION
Use some rules of [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn):
- [no-nested-ternary](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-nested-ternary.md)
- [prefer-ternary](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-ternary.md)
- [text-encoding-identifier-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/text-encoding-identifier-case.md)
- [prefer-number-properties](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-number-properties.md)
- [prefer-switch](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-switch.md)
- [no-lonely-if](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-lonely-if.md)
- [explicit-length-check](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/explicit-length-check.md)
- [no-negated-condition](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-negated-condition.md)
- [prefer-single-call](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-single-call.md)
- [no-useless-fallback-in-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-fallback-in-spread.md)
- [prefer-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-spread.md)
- [prefer-string-slice](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-slice.md)