### PR TITLE
fix: remove force target es2022

### DIFF
--- a/standaloner/src/vite.ts
+++ b/standaloner/src/vite.ts
@@ -49,7 +49,6 @@ const standaloner = (
             external: [...builtinModules, ...builtinModules.map(m => `node:${m}`)],
           },
           build: {
-            target: 'es2022',
             minify: minify && !bundle_,
           },
         };


### PR DESCRIPTION
`standaloner` uses the target `es2022` even the user uses a different one.
`standaloner` should respect the user choice or the default.